### PR TITLE
Fix the issue with install scripts having a hardcoded "C:\Users"

### DIFF
--- a/rifDatabase/Postgres/production/rif40_database_install.bat
+++ b/rifDatabase/Postgres/production/rif40_database_install.bat
@@ -125,10 +125,10 @@ IF %NEWUSER% EQU "rif40"  (
 )
 
 REM
-REM Get passwords from C:\Users\%USERNAME%\AppData\Roaming\postgresql\pgpass.conf if it exists
+REM Get passwords from %USERPROFILE%\AppData\Roaming\postgresql\pgpass.conf if it exists
 REM
-SET PGPASSWORDDIR="C:\Users\%USERNAME%\AppData\Roaming\postgresql"
-SET PGPASSWORDFILE="C:\Users\%USERNAME%\AppData\Roaming\postgresql\pgpass.conf"
+SET PGPASSWORDDIR="%USERPROFILE%\AppData\Roaming\postgresql"
+SET PGPASSWORDFILE="%USERPROFILE%\AppData\Roaming\postgresql\pgpass.conf"
 	
 IF NOT EXIST "%PGPASSWORDDIR%" (
 	MKDIR "%PGPASSWORDDIR%"

--- a/rifDatabase/SQLserver/installation/rif40_sahsuland_dev_install.bat
+++ b/rifDatabase/SQLserver/installation/rif40_sahsuland_dev_install.bat
@@ -86,15 +86,15 @@ if %errorlevel% neq 0  (
 REM Does not work in github tree - SQL server needs access permissions!
 REM
 REM BULK INSERT rif_data.lookup_sahsu_grd_level1
-REM FROM 'C:\Users\Peter\Documents\GitHub\rapidInquiryFacility\rifDatabase\SQLserver\installation\..\..\GeospatialData\tileMaker/mssql_lookup_sahsu_grd_level1.csv'     -- Note use of pwd; set via -v pwd="%cd%" in the sqlcmd command line
+REM FROM '%USERPROFILE%\Documents\GitHub\rapidInquiryFacility\rifDatabase\SQLserver\installation\..\..\GeospatialData\tileMaker/mssql_lookup_sahsu_grd_level1.csv'     -- Note use of pwd; set via -v pwd="%cd%" in the sqlcmd command line
 REM WITH
 REM (
-REM        FORMATFILE = 'C:\Users\Peter\Documents\GitHub\rapidInquiryFacility\rifDatabase\SQLserver\installation\..\..\GeospatialData\tileMaker/mssql_lookup_sahsu_grd_level1.fmt',            -- Use a format file
+REM        FORMATFILE = '%USERPROFILE%\Peter\Documents\GitHub\rapidInquiryFacility\rifDatabase\SQLserver\installation\..\..\GeospatialData\tileMaker/mssql_lookup_sahsu_grd_level1.fmt',            -- Use a format file
 REM         TABLOCK                                 -- Table lock
 REM );
 REM
 REM Msg 4861, Level 16, State 1, Server PH-LAPTOP\SQLEXPRESS, Line 7
-REM Cannot bulk load because the file "C:\Users\Peter\Documents\GitHub\rapidInquiryFacility\rifDatabase\SQLserver\installation\..\..\GeospatialData\tileMaker/mssql_lookup_sahsu_grd_level1.csv" could not be opened. Operating system error code 5(Access is denied.).
+REM Cannot bulk load because the file "%USERPROFILE%\Peter\Documents\GitHub\rapidInquiryFacility\rifDatabase\SQLserver\installation\..\..\GeospatialData\tileMaker/mssql_lookup_sahsu_grd_level1.csv" could not be opened. Operating system error code 5(Access is denied.).
 REM
 REM CREATE LOGIN [rif40] WITH PASSWORD='rif40', CHECK_POLICY = OFF;
 


### PR DESCRIPTION
Use the system-supplied `%USERPROFILE%`, instead of hardcoded `C:\Users`, which causes problems in languages other than English.

I should note that this is not tested.
